### PR TITLE
Issue/16 Strip html tags from license field

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Use Node.js 12
         uses: actions/setup-node@v1
         with:
@@ -29,4 +35,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: docker login docker.pkg.github.com -u magdabot -p ${GH_TOKEN}
       - name: Build Docker Image & Push
-        run: yarn docker-build-prod --repository=docker.pkg.github.com/magda-io/${REPO_NAME} --name=${REPO_NAME} --version=${GITHUB_SHA}
+        run: yarn docker-build-prod --repository=docker.pkg.github.com/magda-io/${REPO_NAME} --name=${REPO_NAME} --version=${GITHUB_SHA} --platform=linux/amd64,linux/arm64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,7 @@ jobs:
       - run: yarn helm-lint
 
       - name: Login to GitHub Package Repository
-        env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: docker login docker.pkg.github.com -u magdabot -p ${GH_TOKEN}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Build Docker Image & Push
-        run: yarn docker-build-prod --repository=docker.pkg.github.com/magda-io/${REPO_NAME} --name=${REPO_NAME} --version=${GITHUB_SHA} --platform=linux/amd64,linux/arm64
+        run: yarn docker-build-prod --repository=ghcr.io/${{ github.repository_owner }} --name=${REPO_NAME} --version=${GITHUB_SHA} --platform=linux/amd64,linux/arm64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Login to GitHub Package Repository
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build Docker Image & Push
+      - name: Build Docker Image & Push to Github Container Registry
         run: yarn docker-build-prod --repository=ghcr.io/${{ github.repository_owner }} --name=${REPO_NAME} --version=${GITHUB_SHA} --platform=linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,11 @@ jobs:
       - name: Re-tag & Push Docker Image to Docker Hub
         run: |
           PACKAGE_JSON_VERSION=$(jq -r ".version" package.json)
+          chmod +r $HOME/.docker/config.json
           docker container run --rm --net host \
             -v regctl-conf:/home/appuser/.regctl/ \
             -v $HOME/.docker/config.json:/home/appuser/.docker/config.json \
-            regclient/regctl:latest image copy ghcr.io/${{ github.repository_owner }}/${REPO_NAME}:${GITHUB_SHA} docker.io/data61/${REPO_NAME}:${PACKAGE_JSON_VERSION}
+            regclient/regctl:0.3.9 image copy ghcr.io/${{ github.repository_owner }}/${REPO_NAME}:${GITHUB_SHA} docker.io/data61/${REPO_NAME}:${PACKAGE_JSON_VERSION}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
           PACKAGE_JSON_VERSION=$(jq -r ".version" package.json)
           docker container run --rm --net host \
             -v regctl-conf:/home/appuser/.regctl/ \
+            -v $HOME/.docker/config.json:/home/appuser/.docker/config.json \
             regclient/regctl:latest image copy ghcr.io/${{ github.repository_owner }}/${REPO_NAME}:${GITHUB_SHA} docker.io/data61/${REPO_NAME}:${PACKAGE_JSON_VERSION}
 
       - name: Configure Git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Use Node.js 10
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Re-tag & Push Docker Image to Docker Hub
         run: |
           PACKAGE_JSON_VERSION=$(jq -r ".version" package.json)
-          docker container run -it --rm --net host \
+          docker container run --rm --net host \
             -v regctl-conf:/home/appuser/.regctl/ \
             regclient/regctl:latest image copy ghcr.io/${{ github.repository_owner }}/${REPO_NAME}:${GITHUB_SHA} docker.io/data61/${REPO_NAME}:${PACKAGE_JSON_VERSION}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           docker container run --rm --net host \
             -v regctl-conf:/home/appuser/.regctl/ \
             -v $HOME/.docker/config.json:/home/appuser/.docker/config.json \
-            regclient/regctl:0.3.9 image copy ghcr.io/${{ github.repository_owner }}/${REPO_NAME}:${GITHUB_SHA} docker.io/data61/${REPO_NAME}:${PACKAGE_JSON_VERSION}
+            regclient/regctl:v0.3.9 image copy ghcr.io/${{ github.repository_owner }}/${REPO_NAME}:${GITHUB_SHA} docker.io/data61/${REPO_NAME}:${PACKAGE_JSON_VERSION}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Use Node.js 10
+      - name: Use Node.js 12
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 12
       - run: yarn install
       - run: yarn build
       - run: yarn test
@@ -47,12 +47,10 @@ jobs:
         run: yarn check-helm-chart-version deploy/${REPO_NAME}/Chart.yaml
 
       - name: Login to GitHub Package Repository
-        env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: docker login docker.pkg.github.com -u ${GH_USERNAME} -p ${GH_TOKEN}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build Docker Image & Push to Github Registry
-        run: yarn docker-build-prod --repository=docker.pkg.github.com/${GH_ORGNAME}/${REPO_NAME} --name=${REPO_NAME}
+      - name: Build Docker Image & Push to Github Container Registry
+        run: yarn docker-build-prod --repository=ghcr.io/${{ github.repository_owner }} --name=${REPO_NAME} --version=${GITHUB_SHA} --platform=linux/amd64,linux/arm64
 
       - name: Login to Docker Hub
         env:
@@ -60,7 +58,11 @@ jobs:
         run: docker login -u ${DH_USERNAME} -p ${DH_TOKEN}
 
       - name: Re-tag & Push Docker Image to Docker Hub
-        run: yarn retag-and-push --fromPrefix=docker.pkg.github.com/${GH_ORGNAME}/${REPO_NAME}/ --fromName=${REPO_NAME}
+        run: |
+          PACKAGE_JSON_VERSION=$(jq -r ".version" package.json)
+          docker container run -it --rm --net host \
+            -v regctl-conf:/home/appuser/.regctl/ \
+            regclient/regctl:latest image copy ghcr.io/${{ github.repository_owner }}/${REPO_NAME}:${GITHUB_SHA} docker.io/data61/${REPO_NAME}:${PACKAGE_JSON_VERSION}
 
       - name: Configure Git
         run: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "protocol": "inspector",
+            "name": "Debug test case",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "cwd": "${workspaceRoot}",
+            "args": [
+                "--require",
+                "ts-node/register",
+                "--require",
+                "tsconfig-paths/register",
+                "src/test/**/*.ts"
+            ]
+        }
+    ]
+}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 -   Switch to github container registry
 -   Use Node 12
 -   Multi-arch docker image release
+-   strip html tags from license field
 
 # 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.1.0
+
+-   Switch to github container registry
+-   Use Node 12
+-   Multi-arch docker image release
+
 # 1.0.0
 
 -   Upgrade dependencies

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,8 @@
 -   Switch to github container registry
 -   Use Node 12
 -   Multi-arch docker image release
--   strip html tags from license field
+-   #16 strip html tags from license field
+-   trim publisher name to avoid unnecessary blank
 
 # 1.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12-alpine
 
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app

--- a/aspect-templates/dcat-distribution-strings.js
+++ b/aspect-templates/dcat-distribution-strings.js
@@ -1,9 +1,11 @@
+var striptags = libraries.striptags;
+
 return {
     title: distribution.title,
     description: distribution.description,
     accessURL: distribution.accessURL,
     downloadURL: distribution.downloadURL,
     mediaType: distribution.mediaType,
-    license: dataset.license,
+    license: dataset.license ? striptags(dataset.license) : "",
     format: distribution.format
 };

--- a/deploy/magda-project-open-data-connector/Chart.yaml
+++ b/deploy/magda-project-open-data-connector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: magda-project-open-data-connector
 description: A Helm chart for Magda Project Open Data Connector
-version: "1.0.0"
+version: "1.1.0"
 kubeVersion: ">= 1.14.0-0"
 home: "https://github.com/magda-io/magda-project-open-data-connector"
 sources:

--- a/deploy/magda-project-open-data-connector/Chart.yaml
+++ b/deploy/magda-project-open-data-connector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: magda-project-open-data-connector
 description: A Helm chart for Magda Project Open Data Connector
-version: "1.1.0"
+version: "1.1.0-alpha.0"
 kubeVersion: ">= 1.14.0-0"
 home: "https://github.com/magda-io/magda-project-open-data-connector"
 sources:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/project-open-data-connector",
   "description": "MAGDA Project Open Data (data.json) Connector",
-  "version": "1.1.0",
+  "version": "1.1.0-alpha.0",
   "license": "Apache-2.0",
   "scripts": {
     "prebuild": "rimraf dist tsconfig.tsbuildinfo",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/mocha": "^7.0.1",
     "@types/read-pkg-up": "^3.0.1",
     "@types/request": "^2.48.1",
+    "@types/striptags": "^3.1.1",
     "@types/turndown": "^5.0.0",
     "@types/yargs": "^12.0.8",
     "chai": "^4.2.0",
@@ -58,6 +59,7 @@
     "moment": "^2.17.1",
     "read-pkg-up": "^3.0.0",
     "request": "^2.88.0",
+    "striptags": "^3.2.0",
     "turndown": "^5.0.1",
     "urijs": "^1.18.12",
     "yargs": "^12.0.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@magda/project-open-data-connector",
   "description": "MAGDA Project Open Data (data.json) Connector",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "scripts": {
     "prebuild": "rimraf dist tsconfig.tsbuildinfo",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "devDependencies": {
     "@magda/ci-utils": "^1.0.2",
-    "@magda/connector-test-utils": "^0.0.60",
-    "@magda/docker-utils": "^0.0.60",
+    "@magda/connector-test-utils": "^1.1.0-alpha.3",
+    "@magda/docker-utils": "^1.1.0-alpha.3",
     "@types/chai": "^4.2.8",
     "@types/jsonpath": "^0.1.29",
     "@types/lodash": "^4.14.66",
@@ -49,9 +49,9 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
-    "@magda/connector-sdk": "^0.0.60",
-    "@magda/registry-aspects": "^0.0.60",
-    "@magda/utils": "^0.0.60",
+    "@magda/connector-sdk": "^1.1.0-alpha.3",
+    "@magda/registry-aspects": "^1.1.0-alpha.3",
+    "@magda/utils": "^1.1.0-alpha.3",
     "@types/to-markdown": "^3.0.0",
     "jsonpath": "^1.0.0",
     "lodash": "^4.17.4",

--- a/src/ProjectOpenData.ts
+++ b/src/ProjectOpenData.ts
@@ -1,6 +1,7 @@
 import { AsyncPage, formatServiceError, retry, request } from "@magda/utils";
 import { ConnectorSource } from "@magda/connector-sdk";
 import TurndownService from "turndown";
+import trimString from "./trimString";
 
 export default class ProjectOpenData implements ConnectorSource {
     public readonly id: string;
@@ -95,7 +96,7 @@ export default class ProjectOpenData implements ConnectorSource {
                         reject(error);
                         return;
                     }
-                    resolve(body);
+                    resolve(this.cleanUpSourceData(body));
                 });
             });
 
@@ -112,6 +113,21 @@ export default class ProjectOpenData implements ConnectorSource {
                     )
                 )
         ).then(data => this.getDatasetLicence(data));
+    }
+
+    private cleanUpSourceData(data: any) {
+        if (!data?.dataset?.length) {
+            return data;
+        }
+        for (let i = 0; i < data.dataset.length; i++) {
+            const dataset = data.dataset[i];
+            if (dataset?.publisher?.name) {
+                data.dataset[i].publisher.name = trimString(
+                    dataset.publisher.name
+                );
+            }
+        }
+        return data;
     }
 
     public getJsonDatasets(): AsyncPage<any[]> {

--- a/src/createTransformer.ts
+++ b/src/createTransformer.ts
@@ -4,6 +4,7 @@ import moment from "moment";
 import URI from "urijs";
 import jsonpath from "jsonpath";
 import lodash from "lodash";
+import striptags from "striptags";
 
 export interface CreateTransformerOptions {
     id: string;
@@ -36,6 +37,7 @@ export default function createTransformer({
             URI: URI,
             jsonpath,
             lodash,
+            striptags,
             projectOpenData: Object.freeze({
                 id: id,
                 name: name,

--- a/src/test/black-box.spec.ts
+++ b/src/test/black-box.spec.ts
@@ -1,129 +1,28 @@
 import { runConnectorTest } from "@magda/connector-test-utils";
-
 import { MockOpenDataCatalog } from "./MockOpenDataCatalog";
+
+const fs = require("fs");
+const path = require("path");
+
+const testDataDir = path.resolve(__dirname, "./data");
 
 const TEST_CASES = [
     {
-        input: {
-            "@type": "dcat:Catalog",
-            dataset: [
-                {
-                    "@type": "dcat:Dataset",
-                    identifier: "dataset-id",
-                    description: "dataset-desc",
-                    title: "dataset-title",
-                    license: "dataset-license-url",
-                    keyword: ["key", "words"],
-                    distribution: [
-                        {
-                            "@type": "dcat:Distribution",
-                            downloadURL: "dataset-url/dataset.csv",
-                            mediaType: "text/csv"
-                        },
-                        {
-                            "@type": "dcat:Distribution",
-                            downloadURL: "dataset-url/dataset.json",
-                            mediaType: "application/json"
-                        }
-                    ]
-                }
-            ]
-        },
-        output: {
-            "dist-connector-dataset-id-0": {
-                id: "dist-connector-dataset-id-0",
-                name: "dataset-id-0",
-                aspects: {
-                    "project-open-data-distribution": {
-                        "@type": "dcat:Distribution",
-                        downloadURL: "dataset-url/dataset.csv",
-                        mediaType: "text/csv"
-                    },
-                    "dcat-distribution-strings": {
-                        downloadURL: "dataset-url/dataset.csv",
-                        mediaType: "text/csv",
-                        license: "dataset-license-url"
-                    },
-                    source: {
-                        type: "project-open-data-distribution",
-                        url: "SOURCE",
-                        id: "connector",
-                        name: "Connector"
-                    }
-                },
-                sourceTag: "stag"
-            },
-            "dist-connector-dataset-id-1": {
-                id: "dist-connector-dataset-id-1",
-                name: "dataset-id-1",
-                aspects: {
-                    "project-open-data-distribution": {
-                        "@type": "dcat:Distribution",
-                        downloadURL: "dataset-url/dataset.json",
-                        mediaType: "application/json"
-                    },
-                    "dcat-distribution-strings": {
-                        downloadURL: "dataset-url/dataset.json",
-                        mediaType: "application/json",
-                        license: "dataset-license-url"
-                    },
-                    source: {
-                        type: "project-open-data-distribution",
-                        url: "SOURCE",
-                        id: "connector",
-                        name: "Connector"
-                    }
-                },
-                sourceTag: "stag"
-            },
-            "org-connector-": {
-                id: "org-connector-",
-                aspects: {
-                    source: {
-                        type: "project-open-data-organization",
-                        url: "SOURCE",
-                        id: "connector",
-                        name: "Connector"
-                    },
-                    "organization-details": {}
-                },
-                sourceTag: "stag"
-            },
-            "ds-connector-dataset-id": {
-                id: "ds-connector-dataset-id",
-                name: "dataset-title",
-                aspects: {
-                    "project-open-data-dataset": {
-                        "@type": "dcat:Dataset",
-                        identifier: "dataset-id",
-                        description: "dataset-desc",
-                        title: "dataset-title",
-                        license: "dataset-license-url",
-                        keyword: ["key", "words"]
-                    },
-                    "dcat-dataset-strings": {
-                        title: "dataset-title",
-                        description: "dataset-desc",
-                        temporal: {},
-                        keywords: ["key", "words"]
-                    },
-                    source: {
-                        type: "project-open-data-dataset",
-                        url: "SOURCE",
-                        id: "connector",
-                        name: "Connector"
-                    },
-                    "dataset-distributions": {
-                        distributions: [
-                            "dist-connector-dataset-id-0",
-                            "dist-connector-dataset-id-1"
-                        ]
-                    },
-                    "dataset-publisher": { publisher: "org-connector-" }
-                },
-                sourceTag: "stag"
-            }
-        }
+        input: JSON.parse(
+            fs.readFileSync(path.resolve(testDataDir, "test1-input.json"))
+        ),
+        output: JSON.parse(
+            fs.readFileSync(path.resolve(testDataDir, "test1-output.json"))
+        )
+    },
+    // --- test strip html tags from license field
+    {
+        input: JSON.parse(
+            fs.readFileSync(path.resolve(testDataDir, "test2-input.json"))
+        ),
+        output: JSON.parse(
+            fs.readFileSync(path.resolve(testDataDir, "test2-output.json"))
+        )
     }
 ];
 

--- a/src/test/data/test1-input.json
+++ b/src/test/data/test1-input.json
@@ -1,0 +1,25 @@
+{
+    "@type": "dcat:Catalog",
+    "dataset": [
+        {
+            "@type": "dcat:Dataset",
+            "identifier": "dataset-id",
+            "description": "dataset-desc",
+            "title": "dataset-title",
+            "license": "dataset-license-url",
+            "keyword": ["key", "words"],
+            "distribution": [
+                {
+                    "@type": "dcat:Distribution",
+                    "downloadURL": "dataset-url/dataset.csv",
+                    "mediaType": "text/csv"
+                },
+                {
+                    "@type": "dcat:Distribution",
+                    "downloadURL": "dataset-url/dataset.json",
+                    "mediaType": "application/json"
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/data/test1-output.json
+++ b/src/test/data/test1-output.json
@@ -1,0 +1,95 @@
+{
+    "dist-connector-dataset-id-0": {
+        "id": "dist-connector-dataset-id-0",
+        "name": "dataset-id-0",
+        "aspects": {
+            "project-open-data-distribution": {
+                "@type": "dcat:Distribution",
+                "downloadURL": "dataset-url/dataset.csv",
+                "mediaType": "text/csv"
+            },
+            "dcat-distribution-strings": {
+                "downloadURL": "dataset-url/dataset.csv",
+                "mediaType": "text/csv",
+                "license": "dataset-license-url"
+            },
+            "source": {
+                "type": "project-open-data-distribution",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            }
+        },
+        "sourceTag": "stag"
+    },
+    "dist-connector-dataset-id-1": {
+        "id": "dist-connector-dataset-id-1",
+        "name": "dataset-id-1",
+        "aspects": {
+            "project-open-data-distribution": {
+                "@type": "dcat:Distribution",
+                "downloadURL": "dataset-url/dataset.json",
+                "mediaType": "application/json"
+            },
+            "dcat-distribution-strings": {
+                "downloadURL": "dataset-url/dataset.json",
+                "mediaType": "application/json",
+                "license": "dataset-license-url"
+            },
+            "source": {
+                "type": "project-open-data-distribution",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            }
+        },
+        "sourceTag": "stag"
+    },
+    "org-connector-": {
+        "id": "org-connector-",
+        "aspects": {
+            "source": {
+                "type": "project-open-data-organization",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            },
+            "organization-details": {}
+        },
+        "sourceTag": "stag"
+    },
+    "ds-connector-dataset-id": {
+        "id": "ds-connector-dataset-id",
+        "name": "dataset-title",
+        "aspects": {
+            "project-open-data-dataset": {
+                "@type": "dcat:Dataset",
+                "identifier": "dataset-id",
+                "description": "dataset-desc",
+                "title": "dataset-title",
+                "license": "dataset-license-url",
+                "keyword": ["key", "words"]
+            },
+            "dcat-dataset-strings": {
+                "title": "dataset-title",
+                "description": "dataset-desc",
+                "temporal": {},
+                "keywords": ["key", "words"]
+            },
+            "source": {
+                "type": "project-open-data-dataset",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            },
+            "dataset-distributions": {
+                "distributions": [
+                    "dist-connector-dataset-id-0",
+                    "dist-connector-dataset-id-1"
+                ]
+            },
+            "dataset-publisher": { "publisher": "org-connector-" }
+        },
+        "sourceTag": "stag"
+    }
+}

--- a/src/test/data/test2-input.json
+++ b/src/test/data/test2-input.json
@@ -1,0 +1,71 @@
+{
+    "@type": "dcat:Catalog",
+    "dataset": [
+        {
+            "@type": "dcat:Dataset",
+            "identifier": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2",
+            "license": "<div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><a href='https://creativecommons.org/licenses/by/4.0/' rel='nofollow ugc' style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 121, 193); text-decoration-line:none;'>Creative<span style='letter-spacing:0.35pt;'> </span>Common<span style='letter-spacing:0.35pt;'> </span><span style='letter-spacing:0pt;'>By</span><span style='letter-spacing:0.25pt;'> </span>Attribution<span style='letter-spacing:0.35pt;'> </span>4.0<span style='letter-spacing:0.3pt;'> </span>(Australian<span style='letter-spacing:0.4pt;'> </span>Capital<span style='letter-spacing:0.3pt;'> </span>Territory)</a><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'>Please read </span><a href='https://www.actmapi.act.gov.au/terms.html' rel='nofollow ugc' target='_blank'>Data Terms and Conditions</a><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'> statement before use of the data.</span></div>",
+            "landingPage": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2",
+            "title": "Bushfire Abatement Zone",
+            "description": "<div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:13.3333px; text-align:justify;'><font face='Arial, Verdana' style='font-weight:bold;'>Part of the Strategic Bushfire Management Plan - Bushfire Abatement Zone</font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:13.3333px; text-align:justify;'><font face='Arial, Verdana' style='font-weight:bold;'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-size:small;'>Under the Emergencies Act, the Commissioner has declared a BAZ. </span></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-size:small;'><br /></span></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'>The BAZ surrounds Canberra and extends west towards the Murrumbidgee River. It is a subset of the BPA, and was developed to identify rural areas where specific measures are required to reduce risk to life and property to the built-up area of Canberra. These measures include land-use constraints, planning requirements for land managers (both public and private) and pre-incident planning for bushfires. </font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'>The BAZ will be reviewed as required to reflect changes in land use and tenure, and will be approved by the Commissioner.</font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><a href='https://creativecommons.org/licenses/by/4.0/' rel='nofollow ugc' style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 121, 193); text-decoration-line:none;'>Creative<span style='letter-spacing:0.35pt;'> </span>Common<span style='letter-spacing:0.35pt;'> </span><span style='letter-spacing:0pt;'>By</span><span style='letter-spacing:0.25pt;'> </span>Attribution<span style='letter-spacing:0.35pt;'> </span>4.0<span style='letter-spacing:0.3pt;'> </span>(Australian<span style='letter-spacing:0.4pt;'> </span>Capital<span style='letter-spacing:0.3pt;'> </span>Territory)</a><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'>Please read </span><a href='https://www.actmapi.act.gov.au/terms.html' rel='nofollow ugc' target='_blank'>Data Terms and Conditions</a><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'> statement before use of the data.</span><br /></div>",
+            "keyword": ["sbmp", "GDA2020", "Emergency Management"],
+            "issued": "2021-08-25T05:54:47.000Z",
+            "modified": "2021-09-03T06:07:01.000Z",
+            "publisher": {
+                "name": "            ACT Government Online Maps and Apps"
+            },
+            "contactPoint": {
+                "@type": "vcard:Contact",
+                "fn": "ACTmapi",
+                "hasEmail": "mailto:spatialdata@act.gov.au"
+            },
+            "accessLevel": "public",
+            "spatial": "148.9099,-35.5264,149.2687,-35.1218",
+            "distribution": [
+                {
+                    "@type": "dcat:Distribution",
+                    "title": "ArcGIS Hub Dataset",
+                    "format": "Web Page",
+                    "mediaType": "text/html",
+                    "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2"
+                },
+                {
+                    "@type": "dcat:Distribution",
+                    "title": "ArcGIS GeoService",
+                    "format": "ArcGIS GeoServices REST API",
+                    "mediaType": "application/json",
+                    "accessURL": "https://data.actmapi.act.gov.au/arcgis/rest/services/ACT_EMERGENCY_MANAGEMENT/esa_sbmp_BAZ_current/MapServer/0"
+                },
+                {
+                    "@type": "dcat:Distribution",
+                    "title": "GeoJSON",
+                    "format": "GeoJSON",
+                    "mediaType": "application/vnd.geo+json",
+                    "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.geojson?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D"
+                },
+                {
+                    "@type": "dcat:Distribution",
+                    "title": "CSV",
+                    "format": "CSV",
+                    "mediaType": "text/csv",
+                    "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.csv?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D"
+                },
+                {
+                    "@type": "dcat:Distribution",
+                    "title": "KML",
+                    "format": "KML",
+                    "mediaType": "application/vnd.google-earth.kml+xml",
+                    "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.kml?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D"
+                },
+                {
+                    "@type": "dcat:Distribution",
+                    "title": "Shapefile",
+                    "format": "ZIP",
+                    "mediaType": "application/zip",
+                    "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.zip?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D"
+                }
+            ],
+            "theme": ["geospatial"]
+        }
+    ]
+}

--- a/src/test/data/test2-output.json
+++ b/src/test/data/test2-output.json
@@ -161,9 +161,9 @@
         },
         "sourceTag": "stag"
     },
-    "org-connector-            ACT Government Online Maps and Apps": {
-        "id": "org-connector-            ACT Government Online Maps and Apps",
-        "name": "            ACT Government Online Maps and Apps",
+    "org-connector-ACT Government Online Maps and Apps": {
+        "id": "org-connector-ACT Government Online Maps and Apps",
+        "name": "ACT Government Online Maps and Apps",
         "aspects": {
             "source": {
                 "type": "project-open-data-organization",
@@ -172,7 +172,7 @@
                 "name": "Connector"
             },
             "organization-details": {
-                "name": "            ACT Government Online Maps and Apps",
+                "name": "ACT Government Online Maps and Apps",
                 "title": "ACT Government Online Maps and Apps",
                 "email": "spatialdata@act.gov.au"
             }
@@ -194,7 +194,7 @@
                 "issued": "2021-08-25T05:54:47.000Z",
                 "modified": "2021-09-03T06:07:01.000Z",
                 "publisher": {
-                    "name": "            ACT Government Online Maps and Apps"
+                    "name": "ACT Government Online Maps and Apps"
                 },
                 "contactPoint": {
                     "@type": "vcard:Contact",
@@ -209,7 +209,7 @@
                 "title": "Bushfire Abatement Zone",
                 "description": "<div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:13.3333px; text-align:justify;'><font face='Arial, Verdana' style='font-weight:bold;'>Part of the Strategic Bushfire Management Plan - Bushfire Abatement Zone</font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:13.3333px; text-align:justify;'><font face='Arial, Verdana' style='font-weight:bold;'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-size:small;'>Under the Emergencies Act, the Commissioner has declared a BAZ. </span></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-size:small;'><br /></span></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'>The BAZ surrounds Canberra and extends west towards the Murrumbidgee River. It is a subset of the BPA, and was developed to identify rural areas where specific measures are required to reduce risk to life and property to the built-up area of Canberra. These measures include land-use constraints, planning requirements for land managers (both public and private) and pre-incident planning for bushfires. </font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'>The BAZ will be reviewed as required to reflect changes in land use and tenure, and will be approved by the Commissioner.</font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><a href='https://creativecommons.org/licenses/by/4.0/' rel='nofollow ugc' style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 121, 193); text-decoration-line:none;'>Creative<span style='letter-spacing:0.35pt;'> </span>Common<span style='letter-spacing:0.35pt;'> </span><span style='letter-spacing:0pt;'>By</span><span style='letter-spacing:0.25pt;'> </span>Attribution<span style='letter-spacing:0.35pt;'> </span>4.0<span style='letter-spacing:0.3pt;'> </span>(Australian<span style='letter-spacing:0.4pt;'> </span>Capital<span style='letter-spacing:0.3pt;'> </span>Territory)</a><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'>Please read </span><a href='https://www.actmapi.act.gov.au/terms.html' rel='nofollow ugc' target='_blank'>Data Terms and Conditions</a><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'> statement before use of the data.</span><br /></div>",
                 "modified": "2021-09-03T06:07:01.000Z",
-                "publisher": "            ACT Government Online Maps and Apps",
+                "publisher": "ACT Government Online Maps and Apps",
                 "spatial": "148.9099,-35.5264,149.2687,-35.1218",
                 "temporal": {},
                 "themes": ["geospatial"],
@@ -234,7 +234,7 @@
                 ]
             },
             "dataset-publisher": {
-                "publisher": "org-connector-            ACT Government Online Maps and Apps"
+                "publisher": "org-connector-ACT Government Online Maps and Apps"
             }
         },
         "sourceTag": "stag"

--- a/src/test/data/test2-output.json
+++ b/src/test/data/test2-output.json
@@ -1,0 +1,242 @@
+{
+    "dist-connector-b925faff0a6a78ad1c61c40988ae6cd867319e137cbbf0d8aa35ca767f64af97": {
+        "id": "dist-connector-b925faff0a6a78ad1c61c40988ae6cd867319e137cbbf0d8aa35ca767f64af97",
+        "name": "ArcGIS Hub Dataset",
+        "aspects": {
+            "project-open-data-distribution": {
+                "@type": "dcat:Distribution",
+                "title": "ArcGIS Hub Dataset",
+                "format": "Web Page",
+                "mediaType": "text/html",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2"
+            },
+            "dcat-distribution-strings": {
+                "title": "ArcGIS Hub Dataset",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2",
+                "mediaType": "text/html",
+                "license": "Creative Common By Attribution 4.0 (Australian Capital Territory)Please read Data Terms and Conditions statement before use of the data.",
+                "format": "Web Page"
+            },
+            "source": {
+                "type": "project-open-data-distribution",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            }
+        },
+        "sourceTag": "stag"
+    },
+    "dist-connector-ad97ba757cbd4874356587167e392b02556a42b317d8c37f386d273263664b27": {
+        "id": "dist-connector-ad97ba757cbd4874356587167e392b02556a42b317d8c37f386d273263664b27",
+        "name": "ArcGIS GeoService",
+        "aspects": {
+            "project-open-data-distribution": {
+                "@type": "dcat:Distribution",
+                "title": "ArcGIS GeoService",
+                "format": "ArcGIS GeoServices REST API",
+                "mediaType": "application/json",
+                "accessURL": "https://data.actmapi.act.gov.au/arcgis/rest/services/ACT_EMERGENCY_MANAGEMENT/esa_sbmp_BAZ_current/MapServer/0"
+            },
+            "dcat-distribution-strings": {
+                "title": "ArcGIS GeoService",
+                "accessURL": "https://data.actmapi.act.gov.au/arcgis/rest/services/ACT_EMERGENCY_MANAGEMENT/esa_sbmp_BAZ_current/MapServer/0",
+                "mediaType": "application/json",
+                "license": "Creative Common By Attribution 4.0 (Australian Capital Territory)Please read Data Terms and Conditions statement before use of the data.",
+                "format": "ArcGIS GeoServices REST API"
+            },
+            "source": {
+                "type": "project-open-data-distribution",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            }
+        },
+        "sourceTag": "stag"
+    },
+    "dist-connector-09552436567df17d580831919816ac93a1a42b191c6faf111213a9321896ec2d": {
+        "id": "dist-connector-09552436567df17d580831919816ac93a1a42b191c6faf111213a9321896ec2d",
+        "name": "GeoJSON",
+        "aspects": {
+            "project-open-data-distribution": {
+                "@type": "dcat:Distribution",
+                "title": "GeoJSON",
+                "format": "GeoJSON",
+                "mediaType": "application/vnd.geo+json",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.geojson?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D"
+            },
+            "dcat-distribution-strings": {
+                "title": "GeoJSON",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.geojson?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D",
+                "mediaType": "application/vnd.geo+json",
+                "license": "Creative Common By Attribution 4.0 (Australian Capital Territory)Please read Data Terms and Conditions statement before use of the data.",
+                "format": "GeoJSON"
+            },
+            "source": {
+                "type": "project-open-data-distribution",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            }
+        },
+        "sourceTag": "stag"
+    },
+    "dist-connector-0b9d29ec85b546eaf2908a4f19e9d8fe82c1bd324c37f738a7e7c32b555ab17f": {
+        "id": "dist-connector-0b9d29ec85b546eaf2908a4f19e9d8fe82c1bd324c37f738a7e7c32b555ab17f",
+        "name": "CSV",
+        "aspects": {
+            "project-open-data-distribution": {
+                "@type": "dcat:Distribution",
+                "title": "CSV",
+                "format": "CSV",
+                "mediaType": "text/csv",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.csv?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D"
+            },
+            "dcat-distribution-strings": {
+                "title": "CSV",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.csv?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D",
+                "mediaType": "text/csv",
+                "license": "Creative Common By Attribution 4.0 (Australian Capital Territory)Please read Data Terms and Conditions statement before use of the data.",
+                "format": "CSV"
+            },
+            "source": {
+                "type": "project-open-data-distribution",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            }
+        },
+        "sourceTag": "stag"
+    },
+    "dist-connector-8db60d94f83a60d2c760c9f302d63593c0c63e1a8af46111af10981bea9c55e0": {
+        "id": "dist-connector-8db60d94f83a60d2c760c9f302d63593c0c63e1a8af46111af10981bea9c55e0",
+        "name": "KML",
+        "aspects": {
+            "project-open-data-distribution": {
+                "@type": "dcat:Distribution",
+                "title": "KML",
+                "format": "KML",
+                "mediaType": "application/vnd.google-earth.kml+xml",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.kml?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D"
+            },
+            "dcat-distribution-strings": {
+                "title": "KML",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.kml?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D",
+                "mediaType": "application/vnd.google-earth.kml+xml",
+                "license": "Creative Common By Attribution 4.0 (Australian Capital Territory)Please read Data Terms and Conditions statement before use of the data.",
+                "format": "KML"
+            },
+            "source": {
+                "type": "project-open-data-distribution",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            }
+        },
+        "sourceTag": "stag"
+    },
+    "dist-connector-71fab07c0a26691277c812e9308fd42d7940e786b34585348c8f9d6541c1e326": {
+        "id": "dist-connector-71fab07c0a26691277c812e9308fd42d7940e786b34585348c8f9d6541c1e326",
+        "name": "Shapefile",
+        "aspects": {
+            "project-open-data-distribution": {
+                "@type": "dcat:Distribution",
+                "title": "Shapefile",
+                "format": "ZIP",
+                "mediaType": "application/zip",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.zip?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D"
+            },
+            "dcat-distribution-strings": {
+                "title": "Shapefile",
+                "accessURL": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2.zip?outSR=%7B%22latestWkid%22%3A7855%2C%22wkid%22%3A7855%7D",
+                "mediaType": "application/zip",
+                "license": "Creative Common By Attribution 4.0 (Australian Capital Territory)Please read Data Terms and Conditions statement before use of the data.",
+                "format": "ZIP"
+            },
+            "source": {
+                "type": "project-open-data-distribution",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            }
+        },
+        "sourceTag": "stag"
+    },
+    "org-connector-            ACT Government Online Maps and Apps": {
+        "id": "org-connector-            ACT Government Online Maps and Apps",
+        "name": "            ACT Government Online Maps and Apps",
+        "aspects": {
+            "source": {
+                "type": "project-open-data-organization",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            },
+            "organization-details": {
+                "name": "            ACT Government Online Maps and Apps",
+                "title": "ACT Government Online Maps and Apps",
+                "email": "spatialdata@act.gov.au"
+            }
+        },
+        "sourceTag": "stag"
+    },
+    "ds-connector-https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2": {
+        "id": "ds-connector-https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2",
+        "name": "Bushfire Abatement Zone",
+        "aspects": {
+            "project-open-data-dataset": {
+                "@type": "dcat:Dataset",
+                "identifier": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2",
+                "license": "<div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><a href='https://creativecommons.org/licenses/by/4.0/' rel='nofollow ugc' style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 121, 193); text-decoration-line:none;'>Creative<span style='letter-spacing:0.35pt;'> </span>Common<span style='letter-spacing:0.35pt;'> </span><span style='letter-spacing:0pt;'>By</span><span style='letter-spacing:0.25pt;'> </span>Attribution<span style='letter-spacing:0.35pt;'> </span>4.0<span style='letter-spacing:0.3pt;'> </span>(Australian<span style='letter-spacing:0.4pt;'> </span>Capital<span style='letter-spacing:0.3pt;'> </span>Territory)</a><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'>Please read </span><a href='https://www.actmapi.act.gov.au/terms.html' rel='nofollow ugc' target='_blank'>Data Terms and Conditions</a><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'> statement before use of the data.</span></div>",
+                "landingPage": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2",
+                "title": "Bushfire Abatement Zone",
+                "description": "<div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:13.3333px; text-align:justify;'><font face='Arial, Verdana' style='font-weight:bold;'>Part of the Strategic Bushfire Management Plan - Bushfire Abatement Zone</font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:13.3333px; text-align:justify;'><font face='Arial, Verdana' style='font-weight:bold;'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-size:small;'>Under the Emergencies Act, the Commissioner has declared a BAZ. </span></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-size:small;'><br /></span></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'>The BAZ surrounds Canberra and extends west towards the Murrumbidgee River. It is a subset of the BPA, and was developed to identify rural areas where specific measures are required to reduce risk to life and property to the built-up area of Canberra. These measures include land-use constraints, planning requirements for land managers (both public and private) and pre-incident planning for bushfires. </font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'>The BAZ will be reviewed as required to reflect changes in land use and tenure, and will be approved by the Commissioner.</font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><a href='https://creativecommons.org/licenses/by/4.0/' rel='nofollow ugc' style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 121, 193); text-decoration-line:none;'>Creative<span style='letter-spacing:0.35pt;'> </span>Common<span style='letter-spacing:0.35pt;'> </span><span style='letter-spacing:0pt;'>By</span><span style='letter-spacing:0.25pt;'> </span>Attribution<span style='letter-spacing:0.35pt;'> </span>4.0<span style='letter-spacing:0.3pt;'> </span>(Australian<span style='letter-spacing:0.4pt;'> </span>Capital<span style='letter-spacing:0.3pt;'> </span>Territory)</a><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'>Please read </span><a href='https://www.actmapi.act.gov.au/terms.html' rel='nofollow ugc' target='_blank'>Data Terms and Conditions</a><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'> statement before use of the data.</span><br /></div>",
+                "keyword": ["sbmp", "GDA2020", "Emergency Management"],
+                "issued": "2021-08-25T05:54:47.000Z",
+                "modified": "2021-09-03T06:07:01.000Z",
+                "publisher": {
+                    "name": "            ACT Government Online Maps and Apps"
+                },
+                "contactPoint": {
+                    "@type": "vcard:Contact",
+                    "fn": "ACTmapi",
+                    "hasEmail": "mailto:spatialdata@act.gov.au"
+                },
+                "accessLevel": "public",
+                "spatial": "148.9099,-35.5264,149.2687,-35.1218",
+                "theme": ["geospatial"]
+            },
+            "dcat-dataset-strings": {
+                "title": "Bushfire Abatement Zone",
+                "description": "<div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:13.3333px; text-align:justify;'><font face='Arial, Verdana' style='font-weight:bold;'>Part of the Strategic Bushfire Management Plan - Bushfire Abatement Zone</font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:13.3333px; text-align:justify;'><font face='Arial, Verdana' style='font-weight:bold;'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-size:small;'>Under the Emergencies Act, the Commissioner has declared a BAZ. </span></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-size:small;'><br /></span></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'>The BAZ surrounds Canberra and extends west towards the Murrumbidgee River. It is a subset of the BPA, and was developed to identify rural areas where specific measures are required to reduce risk to life and property to the built-up area of Canberra. These measures include land-use constraints, planning requirements for land managers (both public and private) and pre-incident planning for bushfires. </font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'>The BAZ will be reviewed as required to reflect changes in land use and tenure, and will be approved by the Commissioner.</font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><a href='https://creativecommons.org/licenses/by/4.0/' rel='nofollow ugc' style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 121, 193); text-decoration-line:none;'>Creative<span style='letter-spacing:0.35pt;'> </span>Common<span style='letter-spacing:0.35pt;'> </span><span style='letter-spacing:0pt;'>By</span><span style='letter-spacing:0.25pt;'> </span>Attribution<span style='letter-spacing:0.35pt;'> </span>4.0<span style='letter-spacing:0.3pt;'> </span>(Australian<span style='letter-spacing:0.4pt;'> </span>Capital<span style='letter-spacing:0.3pt;'> </span>Territory)</a><font face='Arial, Verdana' size='2'><br /></font></div><div style='margin:0px; padding:0px; color:rgb(51, 51, 51); font-family:Arial, Verdana; font-size:10pt;'><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'>Please read </span><a href='https://www.actmapi.act.gov.au/terms.html' rel='nofollow ugc' target='_blank'>Data Terms and Conditions</a><span style='font-family:&quot;Avenir Next W01&quot;, &quot;Avenir Next W00&quot;, &quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size:small; color:rgb(0, 0, 31); letter-spacing:-0.05pt;'> statement before use of the data.</span><br /></div>",
+                "modified": "2021-09-03T06:07:01.000Z",
+                "publisher": "            ACT Government Online Maps and Apps",
+                "spatial": "148.9099,-35.5264,149.2687,-35.1218",
+                "temporal": {},
+                "themes": ["geospatial"],
+                "keywords": ["sbmp", "GDA2020", "Emergency Management"],
+                "contactPoint": "ACTmapi",
+                "landingPage": "https://actmapi-actgov.opendata.arcgis.com/datasets/ACTGOV::bushfire-abatement-zone-2"
+            },
+            "source": {
+                "type": "project-open-data-dataset",
+                "url": "SOURCE",
+                "id": "connector",
+                "name": "Connector"
+            },
+            "dataset-distributions": {
+                "distributions": [
+                    "dist-connector-b925faff0a6a78ad1c61c40988ae6cd867319e137cbbf0d8aa35ca767f64af97",
+                    "dist-connector-ad97ba757cbd4874356587167e392b02556a42b317d8c37f386d273263664b27",
+                    "dist-connector-09552436567df17d580831919816ac93a1a42b191c6faf111213a9321896ec2d",
+                    "dist-connector-0b9d29ec85b546eaf2908a4f19e9d8fe82c1bd324c37f738a7e7c32b555ab17f",
+                    "dist-connector-8db60d94f83a60d2c760c9f302d63593c0c63e1a8af46111af10981bea9c55e0",
+                    "dist-connector-71fab07c0a26691277c812e9308fd42d7940e786b34585348c8f9d6541c1e326"
+                ]
+            },
+            "dataset-publisher": {
+                "publisher": "org-connector-            ACT Government Online Maps and Apps"
+            }
+        },
+        "sourceTag": "stag"
+    }
+}

--- a/src/trimString.ts
+++ b/src/trimString.ts
@@ -1,0 +1,12 @@
+function trimString(str: string) {
+    if (!str) {
+        return "";
+    }
+    if (typeof str === "string") {
+        return str.trim();
+    } else {
+        return str + "";
+    }
+}
+
+export default trimString;

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,6 +132,13 @@
     "@types/tough-cookie" "*"
     form-data "^2.5.0"
 
+"@types/striptags@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/striptags/-/striptags-3.1.1.tgz#26322004d802843db36a6bf31a9744e946194108"
+  integrity sha512-t11pzegWB32MpVjCMXD0LoSxsUQESC7CInDtVoEmnPbLWA5hMRSLBa0U/xCOdj6zFQyHlLn0Qmp76kyp/KyfQw==
+  dependencies:
+    striptags "*"
+
 "@types/to-markdown@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/to-markdown/-/to-markdown-3.0.1.tgz#fda05d97f361cfcee874ef10a378814e8f555628"
@@ -4208,6 +4215,11 @@ strip-json-comments@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+striptags@*, striptags@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.2.0.tgz#cc74a137db2de8b0b9a370006334161f7dd67052"
+  integrity sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw==
 
 supports-color@6.0.0:
   version "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,41 +32,41 @@
     recursive-readdir "^2.2.2"
     yaml "^1.10.2"
 
-"@magda/connector-sdk@^0.0.60":
-  version "0.0.60"
-  resolved "https://registry.yarnpkg.com/@magda/connector-sdk/-/connector-sdk-0.0.60.tgz#a753915e8c106776f85e8b95b0784c437a4e90cc"
-  integrity sha512-2vxEd74qY5Bd8p1YGcI7W7BzkOTuxjdJHLgB9JD5BO8U8RIJdC+LTpQyMlPZA6wC64w8xQIQ/HDEkJD7n61ZMQ==
+"@magda/connector-sdk@^1.1.0-alpha.3":
+  version "1.1.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@magda/connector-sdk/-/connector-sdk-1.1.0-alpha.3.tgz#6b709d7eb5b47c31e6113c7e69a5a3e497ea67a0"
+  integrity sha512-kRsfHHQEyKqTnP2aJjAvb/9fTqc9ZTE2fmkcWHpzB/eSyckL2DUdfjZ+o4n06+eUGaXOEBjrGDX/BPv9N72bog==
   dependencies:
     "@types/urijs" "1.19.13"
     "@types/yargs" "^12.0.8"
 
-"@magda/connector-test-utils@^0.0.60":
-  version "0.0.60"
-  resolved "https://registry.yarnpkg.com/@magda/connector-test-utils/-/connector-test-utils-0.0.60.tgz#78c1e6d87986a38d26d74bf1ea693af71cd939aa"
-  integrity sha512-o5IkHxfg88V0aAGLEIuzFxFZzyWK0xR6nNGIB1JZuwb9q4nNtTgA56gAPCAxgyyIuZD7MxIm6Zpeluvs0xg1Mw==
+"@magda/connector-test-utils@^1.1.0-alpha.3":
+  version "1.1.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@magda/connector-test-utils/-/connector-test-utils-1.1.0-alpha.3.tgz#04a0bd114f215b6cc63dd64cc8f2aa92d0fd3870"
+  integrity sha512-qDTQgRhV18e/CkW1iYuqncFJaK2cnh4Ci4DTC2GB6y4a9n/crNuTzFU2qlOZ7CM/Dnps7vo5dRI0GDjZMmCmMA==
   dependencies:
     ts-node "^8.5.2"
     tsconfig-paths "^3.9.0"
 
-"@magda/docker-utils@^0.0.60":
-  version "0.0.60"
-  resolved "https://registry.yarnpkg.com/@magda/docker-utils/-/docker-utils-0.0.60.tgz#7e2002ebdb1472e3206c8e9b8f53730ac298dc33"
-  integrity sha512-jU6mYYeBPkm1cciDOiOqOlSn0Ru5BdhTkpL2qHq3nU+DMLNlgDCHD0sGyCm1iPRaDlo75igO200bFQAR1551pg==
+"@magda/docker-utils@^1.1.0-alpha.3":
+  version "1.1.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@magda/docker-utils/-/docker-utils-1.1.0-alpha.3.tgz#db97dd779f9e611668eb94f5efcf03e8c2b2e993"
+  integrity sha512-o5VIPB24OmhMwJgNFWPsDZS/2T2Tb4fpksDTDyZEYSshGQHdqF28MEcOsRjdpWnOgFRazwP8LRV/+C+TLXN5Yg==
   dependencies:
     fs-extra "^2.1.2"
     is-subdir "^1.0.2"
     lodash "^4.17.5"
     yargs "^12.0.5"
 
-"@magda/registry-aspects@^0.0.60":
-  version "0.0.60"
-  resolved "https://registry.yarnpkg.com/@magda/registry-aspects/-/registry-aspects-0.0.60.tgz#9fc475c655a89676b05cf9d1a56c3372c5e1f571"
-  integrity sha512-z766I1EdfdbVQc4OJcFb3+xfv3cTBwRwI0PktwsvTX/ybLj4dWNcZKpH01LcIKh/uoZ2jtPfBszScp9LUfGY3g==
+"@magda/registry-aspects@^1.1.0-alpha.3":
+  version "1.1.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@magda/registry-aspects/-/registry-aspects-1.1.0-alpha.3.tgz#005b9413bcc1f153e546a55f73e3fd06be6c0769"
+  integrity sha512-lUeCYhFUUSli8JKzNkyMm+9msb7KkK7gt5jai6YkDS6Ut6e4IkVWCq4ib2tSeO9BiZbpD4HhlgWl4NPTI8IWAw==
 
-"@magda/utils@^0.0.60":
-  version "0.0.60"
-  resolved "https://registry.yarnpkg.com/@magda/utils/-/utils-0.0.60.tgz#92d4a3dbe3be60689c68eb25d3880083344ae00c"
-  integrity sha512-tNxxHh4mr/71j9U5hiOpRueRZyl0FsuWQBcBD1egMOS1yK1LPobSMGWaFBdmlKm9jWBHo5JQCIVRFUc7ldCrFQ==
+"@magda/utils@^1.1.0-alpha.3":
+  version "1.1.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@magda/utils/-/utils-1.1.0-alpha.3.tgz#9335df8d3cdfed135e89158982eddf265f99d32d"
+  integrity sha512-OTGk7ts5AQDjLlxUNgFDvE94B44d5cUoxqgaNkstipHWxEkwqxCNF9AMX2uCyObHcLUXnPN8di7/jkTxYbJ0TQ==
   dependencies:
     "@types/request" "^2.48.1"
 


### PR DESCRIPTION
### What this PR does

Fixes #16
-   Switch to github container registry
-   Use Node 12
-   Multi-arch docker image release
-   Strip html tags from license field
-   trim publisher name to avoid unnecessary blank

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
